### PR TITLE
WIP: create a bin file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ We offer that!  We also offer a **human in the loop**, where we'll clean up the 
 * Python 3.6.1+ https://www.python.org/downloads/
 * Install TensorFlow https://www.tensorflow.org/install/
 
-### Steps to run:
+### Install and use:
 
-```
-> git clone git@github.com:nanohop/sketch-to-react-native.git
-> cd sketch-to-react-native
-> npm install
+```sh
+npm i -g sketch-to-react-native
 ```
 
 ### Extract the component from Sketch as an SVG:
@@ -45,10 +43,10 @@ We offer that!  We also offer a **human in the loop**, where we'll clean up the 
 ![Export Instructions 2](images/export_instructions_2.png?raw=true)
 
 
-### Use that SVG file as the argument for convert.js
+### Use that SVG file as the argument
 
-```
-> node convert.js input-file.svg
+```sh
+sketch-to-react-native input-file.svg
 ```
 
 It will run and save the output to the ./output folder.  Make sure to grab both the .js file, and the associated _images_ folder!  Drop that into your React Native application, and see the magic!

--- a/bin/sketch-to-react-native.js
+++ b/bin/sketch-to-react-native.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('./../convert.js')

--- a/convert.js
+++ b/convert.js
@@ -19,7 +19,7 @@ const {
 
 
 const CURRENT_DIR = __dirname
-const INPUT_FILE = process.argv[2]
+const INPUT_FILE = process.argv[1]
 if(!INPUT_FILE || INPUT_FILE == '' || !INPUT_FILE.match(/\.svg$/)) {
   throw "Usage: convert.js [svg_file]"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "svg_to_react",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "convert.js",
+  "bin": {
+    "sketch-to-react-native": "./bin/sketch-to-react-native.js"
+  },
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-node6": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "sketch-to-react-native": "./bin/sketch-to-react-native.js"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "dependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-node6": "^11.0.0",


### PR DESCRIPTION
Hey guys, this PR is to to create a bin file, so user can use it more easy. Is an suggestion, opened on https://github.com/nanohop/sketch-to-react-native/issues/7

I change in Readme the instructions. 
Until now, you dont publish this module on npm. Do you want publish later? Because, if not, I need to change instructions on readme to install directly from git repository. But first, let me know about that please.

I do the following changes in this PR:

- create a bin file
- reference to bin on package.json
- change the main file to `convert.js` instead `index.js`
- change the instruction about convert.js on readme, to global module

let me know more about you want, so we can finish this PR :D